### PR TITLE
fix robots.ts file

### DIFF
--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -25,14 +25,20 @@ export default function robots(): MetadataRoute.Robots {
         rules: [
             {
                 userAgent: '*',
-                allow: '/',
+                allow: [
+                    '/',             // toutes les pages publiques
+                    '/manifest.json',
+                    '/favicon.ico',
+                    '/_next/static/', // permet les JS/CSS
+                    '/_next/image/',  // permet les images optimisées
+                  ],
                 disallow: [
-                    '/api/', // Routes API Next.js
-                    '/_next/', // Fichiers build Next.js
-                    '/studio/', // Sanity Studio
-                    '/studio/*', // Toutes les routes du studio
-                    '/_vercel/', // Fichiers Vercel
-                    '/admin/', // Routes d'administration (si applicable)
+                '/api/',
+                '/studio/',
+                '/studio/*',
+                '/_vercel/',
+                '/admin/',
+                '/_next/data/',  // bloque uniquement les données internes
                 ],
             },
             // Règles spécifiques pour les bots de réseaux sociaux


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: only adjusts `robots()` allow/disallow paths for production crawling; no runtime logic, auth, or data handling changes.
> 
> **Overview**
> Refines `src/app/robots.ts` production crawling rules by switching from a single `allow: '/'` to an explicit allowlist that includes public pages and key Next.js/static assets (e.g., `/_next/static/`, `/_next/image/`).
> 
> Tightens disallowed paths by removing the broad `/_next/` block and instead disallowing specific internal endpoints like `/_next/data/`, while keeping API, studio, Vercel, and admin routes blocked.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4ea91d1a186bce07d94265aaac50e95c9b01c9b1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->